### PR TITLE
log/file-backup.log should be the default log file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/eclipse-kanto/file-backup
 go 1.17
 
 require (
-	github.com/eclipse-kanto/file-upload v0.1.0-M1.0.20220819091951-08d3c358eeb6
+	github.com/eclipse-kanto/file-upload v0.1.0-M1.0.20220902132952-2696050312e5
 	github.com/eclipse/ditto-clients-golang v0.0.0-20211126080925-0676267c80ac
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
-github.com/eclipse-kanto/file-upload v0.1.0-M1.0.20220819091951-08d3c358eeb6 h1:BcL6XT/UnteQJLtF34aOG/2PZBqG44uHwGrD6SG0uwo=
-github.com/eclipse-kanto/file-upload v0.1.0-M1.0.20220819091951-08d3c358eeb6/go.mod h1:9JAFvJxUIFgFAm+gtp+BYE1s/NDo9diQp+3y3F+9eHQ=
+github.com/eclipse-kanto/file-upload v0.1.0-M1.0.20220902132952-2696050312e5 h1:FcUWk2dzKaAb/mVwIEzQfA0v/HB0T3S7IXFGP2/gM2g=
+github.com/eclipse-kanto/file-upload v0.1.0-M1.0.20220902132952-2696050312e5/go.mod h1:9JAFvJxUIFgFAm+gtp+BYE1s/NDo9diQp+3y3F+9eHQ=
 github.com/eclipse/ditto-clients-golang v0.0.0-20211126080253-3e1c6149fede/go.mod h1:hAXWyOdJLxUQTK4nCc3xAHgEU5iQa5a5DzFeS8ErR60=
 github.com/eclipse/ditto-clients-golang v0.0.0-20211126080925-0676267c80ac h1:+Tl05cZOU8RXl95RP2iZ6LFM5CXxTVhz4ux0LtPUYR4=
 github.com/eclipse/ditto-clients-golang v0.0.0-20211126080925-0676267c80ac/go.mod h1:hAXWyOdJLxUQTK4nCc3xAHgEU5iQa5a5DzFeS8ErR60=

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -77,6 +77,7 @@ func ParseFlags(version string) (*BackupFileConfig, flags.ConfigFileMissing) {
 
 	flags.InitFlagVars(flagsConfig, configNames, configSkip)
 	flag.Parse()
+
 	if *printVersion {
 		fmt.Println(version)
 		os.Exit(0)
@@ -85,5 +86,6 @@ func ParseFlags(version string) (*BackupFileConfig, flags.ConfigFileMissing) {
 	config := &BackupFileConfig{}
 	warn := flags.LoadConfigFromFile(*configFile, config, configNames, configSkip)
 	flags.ApplyFlags(config, *flagsConfig)
+
 	return config, warn
 }

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -57,7 +57,7 @@ type BackupFileConfig struct {
 var configNames = map[string]string{
 	"featureID": "BackupAndRestore", "feature": "BackupAndRestore", "period": "Backup period",
 	"action": "backup", "actions": "backups", "running_actions": "uploads/backups",
-	"transfers": "uploads/downloads",
+	"transfers": "uploads/downloads", "logFile": "log/file-backup.log",
 	"mode": "Directory access mode. Restricts which directories can be requested dynamically for backup/restore" +
 		" through '" + client.BackupDirProperty + "' operation property.\nAllowed values are:" +
 		"\n  'strict' - dynamically specifying directory is forbidden, the 'dir' property must be used instead" +
@@ -77,7 +77,6 @@ func ParseFlags(version string) (*BackupFileConfig, flags.ConfigFileMissing) {
 
 	flags.InitFlagVars(flagsConfig, configNames, configSkip)
 	flag.Parse()
-
 	if *printVersion {
 		fmt.Println(version)
 		os.Exit(0)
@@ -86,6 +85,5 @@ func ParseFlags(version string) (*BackupFileConfig, flags.ConfigFileMissing) {
 	config := &BackupFileConfig{}
 	warn := flags.LoadConfigFromFile(*configFile, config, configNames, configSkip)
 	flags.ApplyFlags(config, *flagsConfig)
-
 	return config, warn
 }

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	config.Validate()
 
-	loggerOut, err := logger.SetupLogger(&config.LogConfig)
+	loggerOut, err := logger.SetupLogger(&config.LogConfig, "[FILE BACKUP]")
 	if err != nil {
 		log.Fatalln("Failed to initialize logger: ", err)
 	}


### PR DESCRIPTION
[#14] log/file-backup.log should be the default log file
 - Changed log file to be "log/file-backup.log" as default value
 - Updated to latest version of file upload dependency
 - Fixed prefix to be "[FILE BACKUP]"

Signed-off-by: Velitchko Valkov <Velitchko.Valkov@bosch.io>