### PR TITLE
Systemd service doesn't start with the default configuration

### DIFF
--- a/client/backup.go
+++ b/client/backup.go
@@ -104,7 +104,7 @@ func (cfg *BackupAndRestoreConfig) Validate() {
 
 	if cfg.Dir != "" {
 		if !pathExisting(cfg.Dir) {
-			log.Fatalf("Directory '%s' not found!\n", cfg.Dir)
+			log.Printf("Directory '%s' not found!\n", cfg.Dir)
 		}
 	}
 


### PR DESCRIPTION
[#17] Systemd service doesn't start with the default configuration

 - Made the absence of the given directory not stop the application
 - A warning is printed upon startup instead

Signed-off-by: Velitchko Valkov <Velitchko.Valkov@bosch.io>