### PR TITLE
Changed the copyright headers in all source files to represent the new Eclipse Kanto project lisence scheme

### DIFF
--- a/client/archive.go
+++ b/client/archive.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package client
 

--- a/client/archive_test.go
+++ b/client/archive_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package client
 

--- a/client/backup.go
+++ b/client/backup.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package client
 

--- a/client/backup_test.go
+++ b/client/backup_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package client
 

--- a/client/command.go
+++ b/client/command.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package client
 

--- a/client/command_test.go
+++ b/client/command_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package client
 

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package flags
 

--- a/internal/flags_test.go
+++ b/internal/flags_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package flags
 

--- a/main.go
+++ b/main.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package main
 


### PR DESCRIPTION
[#21] Apply the new Eclipse Kanto project license scheme

Signed-off-by: Ognian Baruh <Ognyan.Baruh@bosch.io>