### PR TITLE
Specify a default storage location in file-backup.conf

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -1,1 +1,1 @@
-{"logFile": "/var/log/file-backup/file-backup.log", "dir": "/var/tmp/file-backup", "mode": "scoped"}
+{"logFile": "/var/log/file-backup/file-backup.log", "dir": "/var/tmp/file-backup", "mode": "scoped", "storage": "/var/lib/file-backup"}


### PR DESCRIPTION
[#25] Specify a default storage location in file-backup.conf
Modified the config file accordingly

Signed-off-by: Daniel Milchev <fixed-term.daniel.milchev@bosch.io>