### PR TITLE
Add build tag to unit tests

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -41,7 +41,7 @@ jobs:
           go vet ./...
       - name: Test
         run: |
-          go test ./... -coverprofile coverage.out -covermode count
+          go test ./... -coverprofile coverage.out -covermode count -tags=unit
           go tool cover -func coverage.out
       - name: Build Integration Tests
         run: |

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -160,12 +160,6 @@ golang.org/x/text (v0.7.0)
 * Project: https://pkg.go.dev/golang.org/x/text
 * Source:  https://github.com/golang/text/tree/v0.7.0
 
-golang.org/x/crypto (v0.6.0)
-
-* License: BSD 3-Clause "New" or "Revised" License
-* Project: https://pkg.go.dev/golang.org/x/crypto
-* Source:  https://github.com/golang/crypto/tree/v0.6.0
-
 golang.org/x/net (v0.7.0)
 
 * License: BSD 3-Clause "New" or "Revised" License
@@ -184,12 +178,6 @@ azure-sdk-for-go/sdk/azcore (0.20.0)
 * Project: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/azcore 
 * Source:  https://github.com/Azure/azure-sdk-for-go/tree/sdk/azcore/v0.20.0/sdk/azcore
 
-azure-sdk-for-go/sdk/azidentity (0.12.0)
-
-* License: MIT License
-* Project: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/azidentity
-* Source:  https://github.com/Azure/azure-sdk-for-go/tree/sdk/azidentity/v0.12.0/sdk/azidentity
-
 azure-sdk-for-go/sdk/internal (0.8.1)
 
 * License: MIT License
@@ -201,12 +189,6 @@ azure-sdk-for-go/sdk/storage/azblob (0.2.0)
 * License: MIT License
 * Project: https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/storage/azblob
 * Source:  https://github.com/Azure/azure-sdk-for-go/tree/sdk/storage/azblob/v0.2.0/sdk/storage/azblob
-
-pkg/browser (v0.0.0-20180916011732-0a3d74bf9ce4)
-
-* License: BSD 2-Clause "Simplified" License
-* Project: https://github.com/pkg/browser
-* Source:  https://github.com/pkg/browser/tree/0a3d74bf9ce488f035cf5bc36f753a711bc74334
 
 ## Cryptography
 

--- a/client/archive_test.go
+++ b/client/archive_test.go
@@ -10,6 +10,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
+//go:build unit
+
 package client
 
 import (

--- a/client/backup_test.go
+++ b/client/backup_test.go
@@ -10,6 +10,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
+//go:build unit
+
 package client
 
 import (

--- a/client/command_test.go
+++ b/client/command_test.go
@@ -10,6 +10,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
+//go:build unit
+
 package client
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/caarlos0/env/v6 v6.10.1
-	github.com/eclipse-kanto/file-upload v0.1.0-M2.0.20230106094105-baea90603223
+	github.com/eclipse-kanto/file-upload v0.1.0-M2.0.20230227123953-852605ed1a39
 	github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230103144956-911e45a2bf55
 	github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3
 	github.com/eclipse/paho.mqtt.golang v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
-github.com/eclipse-kanto/file-upload v0.1.0-M2.0.20230106094105-baea90603223 h1:XD0YRufUtwEFJ8QiMbokyRhVJni+L15CQjgAfDk0UBo=
-github.com/eclipse-kanto/file-upload v0.1.0-M2.0.20230106094105-baea90603223/go.mod h1:qFMeeksy4TGlQmJ7umUPUQhEaW2KLXLGBY88mUEutqI=
+github.com/eclipse-kanto/file-upload v0.1.0-M2.0.20230227123953-852605ed1a39 h1:PkY5QYjgc/NL8oJCQ1Upd2DzHjuH+vr1SAD451rBXSE=
+github.com/eclipse-kanto/file-upload v0.1.0-M2.0.20230227123953-852605ed1a39/go.mod h1:ebD9wfSdRN8OumMlzSYHrUIZnNplUwVBk0C2vr3unoo=
 github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230103144956-911e45a2bf55 h1:a9tYAvpMoDUfcaGL6HZSEOFq82r8VYP+M2dIzTHve2U=
 github.com/eclipse-kanto/kanto/integration/util v0.0.0-20230103144956-911e45a2bf55/go.mod h1:mhkMBNIG+JDz35JAj8JVWMe0/ROpKmk/i6RYHU6Rea4=
 github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3 h1:bfFGs26yNSfhSi6xmnmykB0jZn1Vu5e1/7JA5Wu5aGc=

--- a/internal/flags_test.go
+++ b/internal/flags_test.go
@@ -10,6 +10,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
+//go:build unit
+
 package flags
 
 import (


### PR DESCRIPTION
[#45] Add build tag to unit tests

- crypto, pkg/browser and azidentity dependencies removed

Signed-off-by: Georgi Boyvalenkov <Georgi.Boyvalenkov@bosch.io>