### PR TITLE
Add coverage label

### DIFF
--- a/.github/workflows/generate-coverage-report.yaml
+++ b/.github/workflows/generate-coverage-report.yaml
@@ -1,0 +1,12 @@
+name: Create Coverage
+
+on: 
+  push:
+    branches:
+    - main
+
+jobs:
+  generate-coverage-report:
+    uses: eclipse-kanto/kanto/.github/workflows/coverage-template.yaml@main
+    with: 
+      coverage-command: go test ./... -coverprofile=coverage.out -covermode count

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-![Kanto logo](https://github.com/eclipse-kanto/kanto/raw/main/logo/kanto.svg)
+[![Kanto logo](https://github.com/eclipse-kanto/kanto/raw/main/logo/kanto.svg)](https://eclipse.dev/kanto/)
 
 # Eclipse Kanto - File Backup
+
+[![Coverage](https://github.com/eclipse-kanto/file-backup/wiki/coverage.svg)](#)
 
 ## Overview
 


### PR DESCRIPTION
[#51] Added coverage label and changed kanto logo to open the main page of the site.

Signed-off-by: Daniel Milchev [fixed-term.daniel.milchev@bosch.io](mailto:fixed-term.daniel.milchev@bosch.io)